### PR TITLE
Make html folder if non-existent

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+mkdir -p html
 for chapter in `ls *.asciidoc` 
 do 
     asciidoc --backend=html4 --out-file=html/$chapter.html $chapter


### PR DESCRIPTION
Use `mkdir -p` to create the html folder that is needed for
output of the generated html files.  Include the -p option to
mkdir to not complain if the folder already exists.
