### PR TITLE
Update generated file to remove asciidoc from name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 
 for chapter in `ls *.asciidoc` 
 do 
-    asciidoc --backend=html4 --out-file=html/$chapter.html $chapter
+    chapter_name="${chapter%.*}"
+    asciidoc --backend=html4 --out-file=html/$chapter_name.html $chapter
 done
-cp html/book.asciidoc.html html/index.html
+cp html/book.html html/index.html


### PR DESCRIPTION
Files would get generated as original filename with just the
html extension added to them.

The index.hml when opened would try to point to the files by
name, but without the intermediate asciidoc extension.

Updated to have the build.sh script to drop the asciidoc extension
from the generated file and just have the extension be just html.

e.g. 01_rebar.asciidoc previously got generated as 01_rebar.asciidoc,
but is now generated as 01_rebar.html
