### PR TITLE
Fixes best practices link in menu and avoid 3 warnings

### DIFF
--- a/05_proper.asciidoc
+++ b/05_proper.asciidoc
@@ -410,7 +410,7 @@ Ruby or other language of your choice.)
 
 [source, erlang]
 ----
-include::proper/test_json_vs_python\.erl[]
+include::proper/test_json_vs_python.erl[]
 ----
 
 ==== Testing vs External Model

--- a/11_best_practices.asciidoc
+++ b/11_best_practices.asciidoc
@@ -1,4 +1,4 @@
-=== How to Write code to take advantage of Dialyzer
+== How to Write code to take advantage of Dialyzer
 
 WARNING: This section is a work in progress, feel free to send
 corrections etc as pull request. Please Use advice here with caution

--- a/book.asciidoc
+++ b/book.asciidoc
@@ -34,7 +34,7 @@ performance tests and more.
 * link:08_wrangler.html[Wrangler]
 * link:09_concuerror.html[Concerrer]
 * link:10_ci.html[Contious Integration]
-* link:11_best_practice.html[Best Practice]
+* link:11_best_practices.html[Best Practice]
 
 
 

--- a/outline.asciidoc
+++ b/outline.asciidoc
@@ -1,7 +1,7 @@
 
 
 
-=== Chapters
+== Chapters
 
 * [Preface](preface.asciidoc)
 * [Building With Rebar](rebar.asciidoc)


### PR DESCRIPTION
The 'Best Practice' chapter has its menu link broken (in book.asciidoc) after build script is executed. The other changes are to avoid 3 warnings that appear during build:

asciidoc: WARNING: 05_proper.asciidoc: line 413: include file not found: /home/xxx/testing-erlang-book/proper/test_json_vs_python.erl
asciidoc: WARNING: 11_best_practices.asciidoc: line 1: section title out of sequence: expected level 1, got level 2
asciidoc: WARNING: outline.asciidoc: line 4: section title out of sequence: expected level 1, got level 2
